### PR TITLE
Emergency fix for geocoding problem when rails-views when live

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ deploy:
     repo: sketch-city/harvey-api
   run:
     - "rails db:migrate"
-    - "rails google:import"
     - "rake cleanup"

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -8,7 +8,6 @@ class Need < ApplicationRecord
   has_many :drafts, as: :record
 
   geocoded_by :location_address
-  after_validation :geocode, if: ->(obj){ obj.location_address.present? && obj.location_address_changed? }
 
   def clean_needs
     return [] if tell_us_about_the_supply_needs.blank?

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -1,9 +1,9 @@
 class Need < ApplicationRecord
-  ColumnNames = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "id", "latitude", "location_address", "location_name", "longitude", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_at", "updated_by"]
+  ColumnNames = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "id", "latitude", "location_address", "location_name", "longitude", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "updated_by", "timestamp", "latitude", "longitude"]
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "location_address", "location_name", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_at", "updated_by"]
+  UpdateFields = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "location_address", "location_name", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_by",  "latitude", "longitude"]
 
   has_many :drafts, as: :record
 

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -8,5 +8,4 @@ class Shelter < ApplicationRecord
   has_many :drafts, as: :record
 
   geocoded_by :address
-  after_validation :geocode, if: ->(obj){ obj.address.present? && obj.address_changed? }
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,9 +1,9 @@
 class Shelter < ApplicationRecord
-  ColumnNames = ["accepting", "address", "address_name", "city", "county", "id", "latitude", "longitude", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_at", "updated_by", "volunteer_needs"]
+  ColumnNames = ["accepting", "address", "address_name", "city", "county", "id", "latitude", "longitude", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs", "last_updated", "latitude", "longitude"]
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["accepting", "address", "address_name", "city", "county", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs"]
+  UpdateFields = ["accepting", "address", "address_name", "city", "county", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs", "last_updated", "latitude", "longitude"]
 
   has_many :drafts, as: :record
 

--- a/app/views/needs/_form.html.erb
+++ b/app/views/needs/_form.html.erb
@@ -16,6 +16,15 @@
     <%= f.label :location_name %>
     <%= f.text_field :location_name %>
 
+    <%= f.label :timestamp %>
+    <%= f.text_field :timestamp %>
+
+    <%= f.label :latitude %>
+    <%= f.text_field :latitude %>
+
+    <%= f.label :longitude %>
+    <%= f.text_field :longitude %>
+
     <%= f.label :location_address %>
     <%= f.text_field :location_address %>
 

--- a/app/views/shelters/_form.html.erb
+++ b/app/views/shelters/_form.html.erb
@@ -16,6 +16,15 @@
     <%= f.label :shelter %>
     <%= f.text_field :shelter %>
 
+    <%= f.label :last_updated %>
+    <%= f.text_field :last_updated %>
+
+    <%= f.label :latitude %>
+    <%= f.text_field :latitude %>
+
+    <%= f.label :longitude %>
+    <%= f.text_field :longitude %>
+
     <%= f.label :address %>
     <%= f.text_field :address %>
 


### PR DESCRIPTION
This is already live on Heroku due to the emergency nature of needing to *stop* rails from geocoding needs / shelters.

Specifically, the shelter started to geocode its one results, based on the `address` field. But the address field sometimes had city, sometimes not. So results got _very_ bad _very_ quickly.