### PR TITLE
Move the Show/Update Links

### DIFF
--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -1,20 +1,20 @@
 <table id="data-table">
   <thead>
     <tr>
+      <th></th>
       <% headers.each do |header| %>
         <th><%= header %></th>
       <% end %>
-      <th></th>
     </tr>
   </thead>
 
   <tbody>
     <% rows.each do |row| %>
       <tr>
+        <td><%= link_to 'Show', row %> / <%= link_to 'Update', [:edit, row] %></td>
         <% columns.each do |column| %>
           <td><%= truncate(row.send(column).to_s) %></td>
         <% end %>
-        <td><%= link_to 'Show', row %> / <%= link_to 'Update', [:edit, row] %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -22,6 +22,8 @@
 
 <script>
 window.onload = function() {
-  $('#data-table').DataTable();
+  $('#data-table').DataTable({
+    "order": [[ 1, "desc" ]]
+  });
 };
 </script>


### PR DESCRIPTION
Baby change.

The main action on the Shelters and Needs tables is to Update a row. I'm moving that link to the first column so that it's visible without having to scroll.

Full disclosure: I did not set up a local environment, so I have not tested this.