### PR TITLE
load the ENV correctly using erb tags 

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -10,5 +10,5 @@ test:
 
 production:
   adapter: redis
-  url: ENV["REDIS_URL"]
+  url: <%= ENV["REDIS_URL"] %>
   channel_prefix: harvey-api_production


### PR DESCRIPTION
When going live with #36 the production cable.yml was formatted incorrectly.

Fix and deployed, so this is already live.

[ci skip]