### PR TITLE
Rearranging Fields

### DIFF
--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -1,9 +1,9 @@
 class Need < ApplicationRecord
-  ColumnNames = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "id", "latitude", "location_address", "location_name", "longitude", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_at", "updated_by"]
+  ColumnNames = ["id", "location_name", "location_address", "contact_for_this_location_name", "contact_for_this_location_phone_number", "are_supplies_needed", "tell_us_about_the_supply_needs", "are_volunteers_needed", "tell_us_about_the_volunteer_needs", "anything_else_you_would_like_to_tell_us", "source", "created_at", "timestamp", "updated_at", "updated_by", "latitude", "longitude"]
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "location_address", "location_name", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_at", "updated_by"]
+  UpdateFields = ["location_name", "location_address", "contact_for_this_location_name", "contact_for_this_location_phone_number", "are_supplies_needed", "tell_us_about_the_supply_needs", "are_volunteers_needed", "tell_us_about_the_volunteer_needs", "anything_else_you_would_like_to_tell_us", "source", "timestamp", "updated_at", "updated_by"]
 
   has_many :drafts, as: :record
 

--- a/app/models/need.rb
+++ b/app/models/need.rb
@@ -3,7 +3,7 @@ class Need < ApplicationRecord
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["location_name", "location_address", "contact_for_this_location_name", "contact_for_this_location_phone_number", "are_supplies_needed", "tell_us_about_the_supply_needs", "are_volunteers_needed", "tell_us_about_the_volunteer_needs", "anything_else_you_would_like_to_tell_us", "source", "timestamp", "updated_at", "updated_by"]
+  UpdateFields = ["anything_else_you_would_like_to_tell_us", "are_supplies_needed", "are_volunteers_needed", "contact_for_this_location_name", "contact_for_this_location_phone_number", "created_at", "location_address", "location_name", "source", "tell_us_about_the_supply_needs", "tell_us_about_the_volunteer_needs", "timestamp", "updated_at", "updated_by"]
 
   has_many :drafts, as: :record
 

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -3,7 +3,7 @@ class Shelter < ApplicationRecord
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["shelter", "address", "address_name", "city", "county", "phone", "accepting", "pets", "volunteer_needs", "supply_needs", "notes", "source", "updated_by", "last_updated", "latitude", "longitude"]
+  UpdateFields = ["accepting", "address", "address_name", "city", "county", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs", "last_updated", "latitude", "longitude"]
 
   has_many :drafts, as: :record
   default_scope { where(active: !false) }

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,9 +1,9 @@
 class Shelter < ApplicationRecord
-  ColumnNames = ["accepting", "address", "address_name", "city", "county", "id", "latitude", "longitude", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs", "last_updated", "latitude", "longitude"]
+  ColumnNames = ["id", "shelter", "address", "address_name", "city", "county", "phone", "accepting", "pets", "volunteer_needs", "supply_needs", "notes", "source", "updated_by", "last_updated", "latitude", "longitude"]
 
   HeaderNames = ColumnNames.map(&:titleize)
 
-  UpdateFields = ["accepting", "address", "address_name", "city", "county", "notes", "pets", "phone", "shelter", "source", "supply_needs", "updated_by", "volunteer_needs", "last_updated", "latitude", "longitude"]
+  UpdateFields = ["shelter", "address", "address_name", "city", "county", "phone", "accepting", "pets", "volunteer_needs", "supply_needs", "notes", "source", "updated_by", "last_updated", "latitude", "longitude"]
 
   has_many :drafts, as: :record
   default_scope { where(active: !false) }


### PR DESCRIPTION
Another baby change (reordering the columns). Also, `latitude` and `longitude` appeared twice in the shelter column names. I remove the duplicates, hope that's ok!

Full disclosure: I did not set up a local environment, so I have not tested this.