### PR TITLE
Add geodata to shelter

### DIFF
--- a/lib/tasks/geodata.rake
+++ b/lib/tasks/geodata.rake
@@ -1,0 +1,11 @@
+namespace :shelter do
+  desc "Populate empty coordinates for shelter data"
+  task :backfill_geo_data => :environment do
+    Shelter.where(:latitude => nil, :longitude => nil).each do |shelter|
+      next if !(shelter.address.present? && shelter.city.present?)
+
+      lat, lng = Geocoder.coordinates("#{shelter.address}, #{shelter.city}")
+      shelter.update_attributes(latitude: lat, longitude: lng)
+    end
+  end
+end

--- a/test/tasks/geodata_test.rb
+++ b/test/tasks/geodata_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class GeoDataRakeTask < ActiveSupport::TestCase
+  def add_stub(shelter, lat, lng)
+    Geocoder::Lookup::Test.add_stub("#{shelter.address}, #{shelter.city}", [{
+      'latitude' => lat,
+      'longitude' => lng
+    }])
+  end
+
+  test "when the geo data is missing it fills in missing geo data" do
+    address = "1010 Waugh"
+    city = "Houston"
+
+    stubbed_lat = 29.7488469
+    stubbed_lng = -95.4593152
+
+    shelter = Shelter.create!({
+      shelter: "Houston Area Women's Center",
+      address: address,
+      city: city
+    })
+
+    add_stub(shelter, stubbed_lat, stubbed_lng)
+
+    assert(shelter.valid?)
+    Rake::Task['shelter:backfill_geo_data'].invoke
+
+    shelter.reload
+    assert_equal(shelter.latitude, stubbed_lat)
+    assert_equal(shelter.longitude, stubbed_lng)
+  end
+
+  test "when the geo data is not missing it does not change that record" do
+    shelter = shelters(:nrg)
+    shelter_2 = shelters(:lonestar)
+
+    add_stub(shelter, rand, rand)
+    add_stub(shelter_2, rand, rand)
+
+    assert(shelter.latitude)
+    assert(shelter.longitude)
+
+    assert_no_difference ['shelter.updated_at', 'shelter.latitude', 'shelter.longitude'] do
+      Rake::Task['shelter:backfill_geo_data'].invoke
+    end
+  end
+end
+

--- a/test/tasks/geodata_test.rb
+++ b/test/tasks/geodata_test.rb
@@ -1,3 +1,4 @@
+require 'rake'
 require 'test_helper'
 
 class GeoDataRakeTask < ActiveSupport::TestCase
@@ -26,9 +27,8 @@ class GeoDataRakeTask < ActiveSupport::TestCase
     assert(shelter.valid?)
     Rake::Task['shelter:backfill_geo_data'].invoke
 
-    shelter.reload
-    assert_equal(shelter.latitude, stubbed_lat)
-    assert_equal(shelter.longitude, stubbed_lng)
+    assert_equal(shelter.reload.latitude, stubbed_lat)
+    assert_equal(shelter.reload.longitude, stubbed_lng)
   end
 
   test "when the geo data is not missing it does not change that record" do
@@ -38,8 +38,8 @@ class GeoDataRakeTask < ActiveSupport::TestCase
     add_stub(shelter, rand, rand)
     add_stub(shelter_2, rand, rand)
 
-    assert(shelter.latitude)
-    assert(shelter.longitude)
+    assert(shelter.reload.latitude)
+    assert(shelter.reload.longitude)
 
     assert_no_difference ['shelter.updated_at', 'shelter.latitude', 'shelter.longitude'] do
       Rake::Task['shelter:backfill_geo_data'].invoke

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,4 +22,6 @@ class ActiveSupport::TestCase
       }
     ]
   )
+
+  Rails.application.load_tasks
 end


### PR DESCRIPTION
run `rake shelter: backfill_geo_data` to populate missing lat and long
FYI: @JoeGaebel, I rebased master to resolve merge conflict and fix CI