### PR TITLE
Device uuids

### DIFF
--- a/app/controllers/api/v1/connect/categories_controller.rb
+++ b/app/controllers/api/v1/connect/categories_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Api
   module V1
     module Connect

--- a/app/controllers/api/v1/connect/markers_controller.rb
+++ b/app/controllers/api/v1/connect/markers_controller.rb
@@ -61,7 +61,8 @@ module Api
                         :phone,
                         :resolved)
                 .tap do |marker|
-                  marker[:data] = params[:marker].require(:data).permit! if params[:marker].key?(:data)
+                  marker[:device_uuid] = params.dig(:marker, :device_uuid) if action_name == "create"
+                  marker[:data] = params.dig(:marker, :data).permit! if params.dig(:marker, :data)
                 end
         end
       end

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -1,18 +1,26 @@
-class Connect::Marker < ApplicationRecord
-  MARKER_TYPES = %w(have need)
+# frozen_string_literal: true
 
-  validates :category, :device_uuid, :name, :phone, presence: true
-  validates :marker_type, inclusion: { in: MARKER_TYPES, allow_blank: false }
-  validates :latitude, :longitude, numericality: { other_than: 0 }
-  validates :email, format: { with: /@/, allow_nil: true }
+module Connect
+  class Marker < ApplicationRecord
+    MARKER_TYPES = %w[have need].freeze
 
-  reverse_geocoded_by :latitude, :longitude
-  after_validation :reverse_geocode, if: :coordinates_changed?
+    validates :category, :device_uuid, :name, :phone, presence: true
+    validates :marker_type, inclusion: { in: MARKER_TYPES, allow_blank: false }
+    validates :latitude, :longitude, numericality: { other_than: 0 }
+    validates :email, format: { with: /@/, allow_nil: true }
 
-  scope :unresolved, -> { where(resolved: false) }
+    reverse_geocoded_by :latitude, :longitude
+    after_validation :reverse_geocode, if: :coordinates_changed?
 
-  def coordinates_changed?
-    return false if self.latitude.zero? || self.longitude.zero?
-    self.latitude_changed? || self.longitude_changed?
+    scope :by_category, ->(category) { where('category ILIKE ?', "%#{category}%") }
+    scope :by_device_uuid, ->(device_uuid) { where(device_uuid: device_uuid) }
+    scope :by_type, ->(type) { where(marker_type: type) }
+    scope :resolved, -> { where(resolved: true) }
+    scope :unresolved, -> { where(resolved: false) }
+
+    def coordinates_changed?
+      return false if latitude.zero? || longitude.zero?
+      latitude_changed? || longitude_changed?
+    end
   end
 end

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -1,7 +1,7 @@
 class Connect::Marker < ApplicationRecord
   MARKER_TYPES = %w(have need)
 
-  validates :category, :name, :phone, presence: true
+  validates :category, :device_uuid, :name, :phone, presence: true
   validates :marker_type, inclusion: { in: MARKER_TYPES, allow_blank: false }
   validates :latitude, :longitude, numericality: { other_than: 0 }
   validates :email, format: { with: /@/, allow_nil: true }

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -4,7 +4,7 @@ module Connect
   class Marker < ApplicationRecord
     MARKER_TYPES = %w[have need].freeze
 
-    validates :category, :device_uuid, :name, :phone, presence: true
+    validates :categories, :device_uuid, :name, :phone, presence: true
     validates :marker_type, inclusion: { in: MARKER_TYPES, allow_blank: false }
     validates :latitude, :longitude, numericality: { other_than: 0 }
     validates :email, format: { with: /@/, allow_nil: true }
@@ -12,7 +12,7 @@ module Connect
     reverse_geocoded_by :latitude, :longitude
     after_validation :reverse_geocode, if: :coordinates_changed?
 
-    scope :by_category, ->(category) { where('category ILIKE ?', "%#{category}%") }
+    scope :by_category, ->(category) { where('categories ? :category', category: category) }
     scope :by_device_uuid, ->(device_uuid) { where(device_uuid: device_uuid) }
     scope :by_type, ->(type) { where(marker_type: type) }
     scope :resolved, -> { where(resolved: true) }

--- a/app/views/api/v1/connect/markers/index.json.jbuilder
+++ b/app/views/api/v1/connect/markers/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.markers @markers do |marker|
 
-  json.extract! marker, :id, :marker_type, :name, :description, :phone,
-                :category, :latitude, :longitude, :address, :email, :data
+  json.extract! marker, :id, :marker_type, :name, :description, :phone, :category,
+                        :latitude, :longitude, :address, :email, :data, :device_uuid
 
   json.updated_at marker.updated_at.in_time_zone("Central Time (US & Canada)").rfc3339
 end

--- a/app/views/api/v1/connect/markers/index.json.jbuilder
+++ b/app/views/api/v1/connect/markers/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.markers @markers do |marker|
 
-  json.extract! marker, :id, :marker_type, :name, :description, :phone, :category,
-                        :latitude, :longitude, :address, :email, :data, :device_uuid
+  json.extract! marker, :id, :marker_type, :name, :description, :phone,
+                        :categories, :latitude, :longitude, :address, :email, :data
 
   json.updated_at marker.updated_at.in_time_zone("Central Time (US & Canada)").rfc3339
 end

--- a/app/views/api/v1/connect/markers/show.json.jbuilder
+++ b/app/views/api/v1/connect/markers/show.json.jbuilder
@@ -1,4 +1,5 @@
-json.extract! @marker, :id, :marker_type, :name, :description, :phone,
-                :category, :resolved, :latitude, :longitude, :address, :email, :data
+json.extract! @marker, :id, :marker_type, :name, :description, :phone, :category,
+                       :resolved, :latitude, :longitude, :address, :email, :data,
+                       :device_uuid
 
 json.updated_at @marker.updated_at.in_time_zone("Central Time (US & Canada)").rfc3339

--- a/app/views/api/v1/connect/markers/show.json.jbuilder
+++ b/app/views/api/v1/connect/markers/show.json.jbuilder
@@ -1,5 +1,4 @@
-json.extract! @marker, :id, :marker_type, :name, :description, :phone, :category,
-                       :resolved, :latitude, :longitude, :address, :email, :data,
-                       :device_uuid
+json.extract! @marker, :id, :marker_type, :name, :description, :phone, :categories,
+                       :resolved, :latitude, :longitude, :address, :email, :data
 
 json.updated_at @marker.updated_at.in_time_zone("Central Time (US & Canada)").rfc3339

--- a/config/connect_categories.yml
+++ b/config/connect_categories.yml
@@ -50,6 +50,15 @@ default: &default
       - canned_food:
       - dry_foods:
       - basic_staples:
+  icons:
+    # Category keys that need icons will have their
+    # corresponding icon key listed here
+    - labor: user-md
+    - equipment: wrench
+    - supplies: shopping-basket
+    - transportation: car
+    - housing: bed
+    - food: cutlery
   en:
     categories: Categories
     labor: Labor

--- a/db/migrate/20170907152426_add_device_uuid_connect_markers.rb
+++ b/db/migrate/20170907152426_add_device_uuid_connect_markers.rb
@@ -1,0 +1,6 @@
+class AddDeviceUuidConnectMarkers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :connect_markers, :device_uuid, :string, null: false, default: ''
+    add_index :connect_markers, :device_uuid
+  end
+end

--- a/db/migrate/20170908152859_update_category_on_connect_markers.rb
+++ b/db/migrate/20170908152859_update_category_on_connect_markers.rb
@@ -1,0 +1,8 @@
+class UpdateCategoryOnConnectMarkers < ActiveRecord::Migration[5.1]
+  def change
+    # This will lose data, but we don't need/want it anyways
+    remove_column :connect_markers, :category, :string, null: false, default: ""
+    add_column :connect_markers, :categories, :jsonb, null: false, default: {}
+    add_index  :connect_markers, :categories, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170907032253) do
+ActiveRecord::Schema.define(version: 20170907152426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,7 +59,9 @@ ActiveRecord::Schema.define(version: 20170907032253) do
     t.datetime "updated_at", null: false
     t.string "email"
     t.jsonb "data", default: {}, null: false
+    t.string "device_uuid", default: "", null: false
     t.index ["category"], name: "index_connect_markers_on_category"
+    t.index ["device_uuid"], name: "index_connect_markers_on_device_uuid"
     t.index ["latitude", "longitude"], name: "index_connect_markers_on_latitude_and_longitude"
     t.index ["resolved"], name: "index_connect_markers_on_unresolved", where: "(resolved IS FALSE)"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170907152426) do
+ActiveRecord::Schema.define(version: 20170908152859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(version: 20170907152426) do
     t.string "name", default: "", null: false
     t.text "description", default: "", null: false
     t.string "phone", default: "", null: false
-    t.string "category", default: "", null: false
     t.boolean "resolved", default: false, null: false
     t.float "latitude", default: 0.0, null: false
     t.float "longitude", default: 0.0, null: false
@@ -60,7 +59,8 @@ ActiveRecord::Schema.define(version: 20170907152426) do
     t.string "email"
     t.jsonb "data", default: {}, null: false
     t.string "device_uuid", default: "", null: false
-    t.index ["category"], name: "index_connect_markers_on_category"
+    t.jsonb "categories", default: {}, null: false
+    t.index ["categories"], name: "index_connect_markers_on_categories", using: :gin
     t.index ["device_uuid"], name: "index_connect_markers_on_device_uuid"
     t.index ["latitude", "longitude"], name: "index_connect_markers_on_latitude_and_longitude"
     t.index ["resolved"], name: "index_connect_markers_on_unresolved", where: "(resolved IS FALSE)"

--- a/test/controllers/api/v1/connect/markers_controller_test.rb
+++ b/test/controllers/api/v1/connect/markers_controller_test.rb
@@ -4,9 +4,13 @@ require 'test_helper'
 
 class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
 
+  def default_headers(headers = nil)
+    headers || { "DisasterConnect-Device-UUID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
+  end
+
   test "returns all unresolved markers" do
     count = Connect::Marker.unresolved.count
-    get api_v1_connect_markers_path
+    get api_v1_connect_markers_path, headers: default_headers
     json = JSON.parse(response.body)
     assert_equal count, json["markers"].length
     assert_equal count, json["meta"]["result_count"]
@@ -14,7 +18,7 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "can limit the number of markers returned" do
-    get api_v1_connect_markers_path, params: { limit: 1 }
+    get api_v1_connect_markers_path, params: { limit: 1 }, headers: default_headers
     json = JSON.parse(response.body)
     assert_equal 1, json["markers"].length
     assert_equal 1, json["meta"]["result_count"]
@@ -24,43 +28,64 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
   test "can filter markers by proximity" do
     marker = connect_markers(:have)
     filter = { lat: marker.latitude, lon: marker.longitude, rad: 2 }
-    get api_v1_connect_markers_path, params: filter
+    get api_v1_connect_markers_path, params: filter, headers: default_headers
     json = JSON.parse(response.body)
     assert_equal 2, json["markers"].length
   end
 
   test "can filter markers by category" do
-    filter = { category: "shop" }
-    get api_v1_connect_markers_path, params: filter
+    filter = { category: "labor" }
+    get api_v1_connect_markers_path, params: filter, headers: default_headers
     json = JSON.parse(response.body)
     assert_equal 1, json["markers"].length
-    assert_equal 'labor shop', json["markers"][0]["category"]
+    assert json["markers"][0]["categories"].has_key?('labor')
   end
 
   test "can filter markers by device uuid" do
     filter = { device_uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
-    get api_v1_connect_markers_path, params: filter
+    get api_v1_connect_markers_path, params: filter, headers: default_headers
     json = JSON.parse(response.body)
-    assert json["markers"].all? { |m| m["device_uuid"] == filter[:device_uuid] }
+    ids = json["markers"].map { |m| m["id"] }
+    ::Connect::Marker.find(ids).each { |m| assert m.device_uuid == filter[:device_uuid] }
   end
 
   test "should create marker" do
-    keys = %w(marker_type name description category phone latitude longitude data device_uuid)
+    keys = %w(marker_type name description categories phone latitude longitude data device_uuid)
     attribs = connect_markers(:have).attributes.slice(*keys)
     assert_difference('Connect::Marker.count') do
-      post api_v1_connect_markers_path, params: { marker: attribs }
+      post api_v1_connect_markers_path, params: { marker: attribs }, headers: default_headers
     end
     json = JSON.parse(response.body)
     assert_equal attribs["name"], json["name"]
     refute json["data"].keys.empty?
   end
 
+  test "should not create a marker without a device uuid" do
+    keys = %w(marker_type name description categories phone latitude longitude data device_uuid)
+    attribs = connect_markers(:have).attributes.slice(*keys)
+    post api_v1_connect_markers_path, params: { marker: attribs }, headers: default_headers({})
+    assert_response 403
+  end
+
   test "can update a marker" do
     marker = connect_markers(:have)
     assert_difference('Connect::Marker.unresolved.count', -1) do
-      patch api_v1_connect_marker_path(marker), params: { marker: { resolved: true } }
+      patch api_v1_connect_marker_path(marker), params: { marker: { resolved: true } }, headers: default_headers
     end
     json = JSON.parse(response.body)
     assert json["resolved"], 'marker should be marked as resolved'
+  end
+
+  test "can not update a marker without a device uuid" do
+    marker = connect_markers(:have)
+    patch api_v1_connect_marker_path(marker), params: { marker: { resolved: true } }, headers: default_headers({})
+    assert_response 403
+  end
+
+  test "can not update markers that you did not create" do
+    marker = connect_markers(:have)
+    assert_raises ActiveRecord::RecordNotFound do
+      patch api_v1_connect_marker_path(marker), params: { marker: { resolved: true } }, headers: default_headers({ "DisasterConnect-Device-UUID": "threeve" })
+    end
   end
 end

--- a/test/controllers/api/v1/connect/markers_controller_test.rb
+++ b/test/controllers/api/v1/connect/markers_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
@@ -33,6 +35,13 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert_equal 1, json["markers"].length
     assert_equal 'labor shop', json["markers"][0]["category"]
+  end
+
+  test "can filter markers by device uuid" do
+    filter = { device_uuid: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
+    get api_v1_connect_markers_path, params: filter
+    json = JSON.parse(response.body)
+    assert json["markers"].all? { |m| m["device_uuid"] == filter[:device_uuid] }
   end
 
   test "should create marker" do

--- a/test/controllers/api/v1/connect/markers_controller_test.rb
+++ b/test/controllers/api/v1/connect/markers_controller_test.rb
@@ -36,7 +36,7 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create marker" do
-    keys = %w(marker_type name description category phone latitude longitude data)
+    keys = %w(marker_type name description category phone latitude longitude data device_uuid)
     attribs = connect_markers(:have).attributes.slice(*keys)
     assert_difference('Connect::Marker.count') do
       post api_v1_connect_markers_path, params: { marker: attribs }

--- a/test/fixtures/connect/markers.yml
+++ b/test/fixtures/connect/markers.yml
@@ -6,7 +6,14 @@ have:
   name: ChaiOne
   description: MyText
   phone: (888) 316-0357
-  category: Labor Specialized Other Developer resources
+  categories:
+    labor:
+      - muck
+      - rake
+    housing:
+      - for 5 people
+    food:
+      - pork cracklins
   resolved: false
   latitude: 29.7488469
   longitude: -95.4593152
@@ -23,7 +30,8 @@ need:
   name: Joe Blow
   description: Halp
   phone: 713-867-5309
-  category: labor shop
+  categories:
+    foo: bar
   resolved: false
   latitude: 29.773700
   longitude: -95.358611
@@ -34,7 +42,8 @@ close_need:
   name: Joe Close
   description: Halp
   phone: 713-867-5309
-  category: Labor Clean
+  categories:
+    foo: bar
   resolved: false
   latitude: 29.750621
   longitude: -95.457776
@@ -45,7 +54,8 @@ resolved:
   name: Resolved
   description: Halp
   phone: 713-867-5309
-  category: Labor Muck
+  categories:
+    foo: bar
   resolved: true
   latitude: 29.776
   longitude: -95.3587

--- a/test/fixtures/connect/markers.yml
+++ b/test/fixtures/connect/markers.yml
@@ -1,6 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 have:
+  device_uuid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   marker_type: have
   name: ChaiOne
   description: MyText
@@ -17,6 +18,7 @@ have:
     bar: baz
 
 need:
+  device_uuid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   marker_type: need
   name: Joe Blow
   description: Halp
@@ -27,6 +29,7 @@ need:
   longitude: -95.358611
 
 close_need:
+  device_uuid: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
   marker_type: need
   name: Joe Close
   description: Halp
@@ -37,6 +40,7 @@ close_need:
   longitude: -95.457776
 
 resolved:
+  device_uuid: yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
   marker_type: need
   name: Resolved
   description: Halp

--- a/test/models/connect/marker_test.rb
+++ b/test/models/connect/marker_test.rb
@@ -76,4 +76,24 @@ class Connect::MarkerTest < ActiveSupport::TestCase
     refute @marker.valid?, 'saved marker with invalid email'
     assert_not_nil @marker.errors[:email], 'no validation error for email'
   end
+
+  test 'scope by category' do
+    assert Connect::Marker.by_category('muck').all? { |m| m.category =~ /muck/i }
+  end
+
+  test 'scope by device uuid' do
+    assert Connect::Marker.by_device_uuid(@marker.device_uuid).all? { |m| m.device_uuid == @marker.device_uuid }
+  end
+
+  test 'scope by type' do
+    assert Connect::Marker.by_type(@marker.marker_type).all? { |m| m.marker_type == @marker.marker_type }
+  end
+
+  test 'scope resolved' do
+    assert Connect::Marker.resolved.all? { |m| m.resolved }
+  end
+
+  test 'scope unresolved' do
+    assert Connect::Marker.unresolved.none? { |m| m.resolved }
+  end
 end

--- a/test/models/connect/marker_test.rb
+++ b/test/models/connect/marker_test.rb
@@ -25,10 +25,10 @@ class Connect::MarkerTest < ActiveSupport::TestCase
     assert_not_nil @marker.errors[:name], 'no validation error for name present'
   end
 
-  test 'invalid without a category' do
-    @marker.category = nil
-    refute @marker.valid?, 'saved marker without a category'
-    assert_not_nil @marker.errors[:category], 'no validation error for category present'
+  test 'invalid without categories' do
+    @marker.categories = {}
+    refute @marker.valid?, 'saved marker without categories'
+    assert_not_nil @marker.errors[:categories], 'no validation error for categories present'
   end
 
   test 'invalid without a phone' do
@@ -78,7 +78,7 @@ class Connect::MarkerTest < ActiveSupport::TestCase
   end
 
   test 'scope by category' do
-    assert Connect::Marker.by_category('muck').all? { |m| m.category =~ /muck/i }
+    assert Connect::Marker.by_category('labor').all? { |m| m.categories.keys.include?('labor') }
   end
 
   test 'scope by device uuid' do

--- a/test/models/connect/marker_test.rb
+++ b/test/models/connect/marker_test.rb
@@ -11,6 +11,14 @@ class Connect::MarkerTest < ActiveSupport::TestCase
     assert @marker.valid?
   end
 
+  test 'invalid without a device uuid' do
+    ['', nil].each do |blank|
+      @marker.device_uuid = blank
+      refute @marker.valid?, 'saved marker without a device uuid'
+      assert_not_nil @marker.errors[:device_uuid], 'no validation error for device uuid present'
+    end
+  end
+
   test 'invalid without a name' do
     @marker.name = nil
     refute @marker.valid?, 'saved marker without a name'


### PR DESCRIPTION
Adds device uuids to markers allowing clients to identify markers they have created.

Categories endpoint now includes an `icons` key that maps category keys to icon keys. This allows the icons in the app to be updated without resubmitting to the app store.

