### PR TITLE
Automatically geocode on Shelter save

### DIFF
--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -11,14 +11,16 @@ class Shelter < ApplicationRecord
   default_scope { where(active: !false) }
 
   geocoded_by :address
-  after_validation :geocode_if_city_present
+  after_validation :geocode, if: :should_geocode
 
   after_commit do
     ShelterUpdateNotifierJob.perform_later self
   end
 
-  def geocode_if_city_present
-    return unless city.present?
-    geocode
+  private
+
+  def should_geocode
+    (address.present? && city.present?) &&
+      (address_changed? || city_changed?)
   end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -11,6 +11,7 @@ class Shelter < ApplicationRecord
   default_scope { where(active: !false) }
 
   geocoded_by :address
+  after_validation :geocode
 
   after_commit do
     ShelterUpdateNotifierJob.perform_later self

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -11,9 +11,14 @@ class Shelter < ApplicationRecord
   default_scope { where(active: !false) }
 
   geocoded_by :address
-  after_validation :geocode
+  after_validation :geocode_if_city_present
 
   after_commit do
     ShelterUpdateNotifierJob.perform_later self
+  end
+
+  def geocode_if_city_present
+    return unless city.present?
+    geocode
   end
 end

--- a/lib/tasks/geodata.rake
+++ b/lib/tasks/geodata.rake
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 namespace :shelter do
-  desc "Populate empty coordinates for shelter data"
-  task :backfill_geo_data => :environment do
-    Shelter.where(:latitude => nil, :longitude => nil).each do |shelter|
-      next if !(shelter.address.present? && shelter.city.present?)
+  desc 'Populate empty coordinates for shelter data'
+  task backfill_geo_data: :environment do
+    Shelter.where(latitude: nil, longitude: nil).each do |shelter|
+      next if shelter.address.blank? || shelter.city.blank?
 
       lat, lng = Geocoder.coordinates("#{shelter.address}, #{shelter.city}")
       shelter.update_attributes(latitude: lat, longitude: lng)

--- a/test/models/shelter_test.rb
+++ b/test/models/shelter_test.rb
@@ -16,4 +16,15 @@ class ShelterTest < ActiveSupport::TestCase
     assert_not_nil shelter.latitude
     assert_not_nil shelter.longitude
   end
+
+  test 'does not geocode without a city' do
+    shelter = Shelter.create(
+      shelter: "Houston Area Women's Center",
+      address: '1010 Waugh',
+      city: nil
+    )
+
+    assert_nil shelter.latitude
+    assert_nil shelter.longitude
+  end
 end

--- a/test/models/shelter_test.rb
+++ b/test/models/shelter_test.rb
@@ -6,4 +6,14 @@ class ShelterTest < ActiveSupport::TestCase
     assert_equal Shelter.count, 2
   end
 
+  test 'geocodes on save' do
+    shelter = Shelter.create(
+      shelter: "Houston Area Women's Center",
+      address: '1010 Waugh',
+      city: 'Houston'
+    )
+
+    assert_not_nil shelter.latitude
+    assert_not_nil shelter.longitude
+  end
 end

--- a/test/tasks/geodata_test.rb
+++ b/test/tasks/geodata_test.rb
@@ -13,14 +13,14 @@ class GeoDataRakeTask < ActiveSupport::TestCase
     address = "1010 Waugh"
     city = "Houston"
 
-    stubbed_lat = 29.7488469
-    stubbed_lng = -95.4593152
+    stubbed_lat = 29.7496888
+    stubbed_lng = -95.4579427
 
-    shelter = Shelter.create!({
+    shelter = Shelter.create!(
       shelter: "Houston Area Women's Center",
       address: address,
       city: city
-    })
+    )
 
     add_stub(shelter, stubbed_lat, stubbed_lng)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,19 +9,17 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
   Geocoder.configure(lookup: :test)
 
-  Geocoder::Lookup::Test.add_stub(
-    [29.7488469, -95.4593152], [
-      {
-        'latitude'     => 29.7496888,
-        'longitude'    => -95.45794269999999,
-        'address'      => '4800 Hallmark Dr, Houston, TX 77056, USA',
-        'state'        => 'Texas',
-        'state_code'   => 'TX',
-        'country'      => 'United States',
-        'country_code' => 'US'
-      }
-    ]
-  )
+  Geocoder::Lookup::Test.set_default_stub([
+    {
+      'latitude'     => 29.7496888,
+      'longitude'    => -95.45794269999999,
+      'address'      => '4800 Hallmark Dr, Houston, TX 77056, USA',
+      'state'        => 'Texas',
+      'state_code'   => 'TX',
+      'country'      => 'United States',
+      'country_code' => 'US',
+    }
+  ])
 
   Rails.application.load_tasks
 end


### PR DESCRIPTION
Rather than requiring a backfill rake script, let's just geocode each
Shelter entity before it is saved.

This commit adds the recommended `after_validation :geocode` hook in the
`geocode` gem's documentation.