### PR TITLE
Disable travis-ci to irma-api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,12 +38,3 @@ deploy:
     run:
       - "rails db:migrate"
       - "rake cleanup"
-  - provider: heroku
-    api_key:
-      secure: jheoABY2Yhe+eP4DB87h877u4cSc02Rf09PhmRxNroQQHv3XkToVgxXo33TEEuCoucDfhSepOeky4QozarJ7hSHCn1ssPb8jo3klicxPrB90t8SBPHB7evqfcaXAGYZBIPcvoGXzqQ0Brv/IvSP2eK81KUFAA8CAE9jUI4HXJkqRWnL2SC51yytxhnTBruOlTA3Z/90vgj9q6y3Y+xZCP3DrBDoBlvdaeyOXt54X+vcj+ZKepiMTdOuSEkC8dxuLiru7yMWZPANvvP/B/MLnh6XdG/EggRujR/uKvfrRKjKZjRt/TkMM7SarP+klGqOiaHV9KOct28E2Wbmoe03Qllk2NopqsanF4wemUWb8jCp4fLaf6e6KPnzA+Vfr3C8h1AyJYAXDXKx+jAa3pGDSSuDQmvO9lNtpLpxNbVwHSpBvdaY9MDta64oj+5eb2RR/UZZmB8JBuW2+2B22cf/OPU/Z915qWzshE3Fi0pTEgca4Tq37KqzyuYl8n4JnLxsUIWYVytWMMX8JtnvMYJdVLJEWrNidAD/BrZQGRhKUE8vnTMK7sFCzC2XInNpFXXDW0z2Keor8tb0Qk0y+PUyUlwy6YJgmITGkBHcRNWM0tYwO8+DS/duqvlSg0gMdxE6sa6mz9eVk1oP7KBJ/O4VdvJoRkdMiMKC9UvCceLqAT5A=
-    app: irma-api
-    on:
-      repo: sketch-city/harvey-api
-    run:
-      - "rails db:migrate"
-      - "rake cleanup"


### PR DESCRIPTION
History: 

* Irma deployed directly to heroku last night
* our auto deploy did its job when code hit harvey-api master
* clobbered the irma deploy