### PR TITLE
Remove es6 syntax; was failing on deploy. Rails :(

### DIFF
--- a/app/assets/javascripts/components/place_autocomplete.js
+++ b/app/assets/javascripts/components/place_autocomplete.js
@@ -1,91 +1,96 @@
-(function() {
+;(function() {
   function PlaceAutocomplete(el, opts, callback) {
-    var _this = this;
+    var _this = this
 
-    this.el = el;
-    this.opts = opts;
-    this.callback = callback;
+    this.el = el
+    this.opts = opts
+    this.callback = callback
 
-    this.autocomplete = new google.maps.places.Autocomplete(el, {});
+    this.autocomplete = new google.maps.places.Autocomplete(el, {})
 
-    this.autocomplete.addListener('place_changed', function() {
-      var place = _this.autocomplete.getPlace();
+    this.autocomplete.addListener("place_changed", function() {
+      var place = _this.autocomplete.getPlace()
 
       if (!!place.name) {
-        $(_this.opts.fillName).val(place.name);
+        $(_this.opts.fillName).val(place.name)
       } else {
-        $(_this.opts.fillName).val('');
+        $(_this.opts.fillName).val("")
       }
 
       if (!!place.formatted_address) {
-        $(_this.opts.fillAddress).val(place.formatted_address);
+        $(_this.opts.fillAddress).val(place.formatted_address)
       } else {
-        $(_this.opts.fillAddress).val('');
+        $(_this.opts.fillAddress).val("")
       }
 
       if (!!place.formatted_phone_number) {
-        $(_this.opts.fillPhone).val(place.formatted_phone_number);
+        $(_this.opts.fillPhone).val(place.formatted_phone_number)
       } else {
-        $(_this.opts.fillPhone).val('');
+        $(_this.opts.fillPhone).val("")
       }
 
-      var cityComponent = place.address_components.find(
-          c => c.types.indexOf("locality") >= 0
-        )
+      var cityComponent = place.address_components.find(function(c) {
+        return c.types.indexOf("locality") >= 0
+      })
       if (!!cityComponent) {
-        $(_this.opts.fillCity).val(cityComponent.long_name);
+        $(_this.opts.fillCity).val(cityComponent.long_name)
       } else {
-        $(_this.opts.fillCity).val('');
+        $(_this.opts.fillCity).val("")
       }
 
       if (!!place.formatted_phone_number) {
-        $(_this.opts.fillPhone).val(place.formatted_phone_number);
+        $(_this.opts.fillPhone).val(place.formatted_phone_number)
       } else {
-        $(_this.opts.fillPhone).val('');
+        $(_this.opts.fillPhone).val("")
       }
 
       if (!!place.geometry && !!place.geometry.location) {
-        $(_this.opts.fillLat).val(place.geometry.location.lat());
-        $(_this.opts.fillLng).val(place.geometry.location.lng());
+        $(_this.opts.fillLat).val(place.geometry.location.lat())
+        $(_this.opts.fillLng).val(place.geometry.location.lng())
       } else {
-        $(_this.opts.fillLat).val('');
-        $(_this.opts.fillLng).val('');
+        $(_this.opts.fillLat).val("")
+        $(_this.opts.fillLng).val("")
       }
 
       if (!!place.place_id) {
-        $(_this.opts.fillPlaceId).val(place.place_id);
+        $(_this.opts.fillPlaceId).val(place.place_id)
       } else {
-        $(_this.opts.fillPlaceId).val('');
+        $(_this.opts.fillPlaceId).val("")
       }
 
-      if (!!callback){
+      if (!!callback) {
         callback(place)
       }
-    });
+    })
   }
 
-  $(function () {
-    $('input.place-autocomplete').each(function() {
-      var $el = $(this);
+  $(function() {
+    $("input.place-autocomplete").each(function() {
+      var $el = $(this)
 
-      new PlaceAutocomplete(this, {
-        fillName: $el.data('name'),
-        fillAddress: $el.data('address'),
-        fillPhone: $el.data('phone'),
-        fillLat: $el.data('lat'),
-        fillLng: $el.data('lng'),
-        fillPlaceId: $el.data('placeid'),
-        fillCity: $el.data('city')
-      }, (place) => {
-        var selector = $el.data('mapselector')
-        if (!!selector){
-          simpleMap({selector,
-            name: place.name,
-            lat: place.geometry.location.lat(),
-            lng: place.geometry.location.lng()
-          })
+      new PlaceAutocomplete(
+        this,
+        {
+          fillName: $el.data("name"),
+          fillAddress: $el.data("address"),
+          fillPhone: $el.data("phone"),
+          fillLat: $el.data("lat"),
+          fillLng: $el.data("lng"),
+          fillPlaceId: $el.data("placeid"),
+          fillCity: $el.data("city")
+        },
+        function(place) {
+          var selector = $el.data("mapselector")
+          if (!!selector) {
+            simpleMap({
+              selector: selector,
+              name: place.name,
+              lat: place.geometry.location.lat(),
+              lng: place.geometry.location.lng()
+            })
+          }
         }
-      });
-    });
-  });
-})();
+      )
+    })
+  })
+})()

--- a/app/assets/javascripts/simple_map.js
+++ b/app/assets/javascripts/simple_map.js
@@ -1,13 +1,18 @@
-function simpleMap({ selector, name = "Location", lat, lng }) {
+function simpleMap(options) {
+  var selector = options.selector
+  var name = options.name || "Location"
+  var lat = options.lat
+  var lng = options.lng
+
   var element = document.querySelector(selector)
   if (!!element) {
     var map = new google.maps.Map(element, {
       zoom: 12,
-      center: { lat, lng }
+      center: { lat: lat, lng: lng }
     })
 
     var marker = new google.maps.Marker({
-      position: { lat, lng },
+      position: { lat: lat, lng: lng },
       map: map,
       title: name
     })


### PR DESCRIPTION
Removing fat arrows and es6 assignments. Rails not cool with that yet.

Was failing on Travis deploy (https://travis-ci.org/sketch-city/harvey-api/builds/273644488#L1219) with a weird error.

Locally had to run `RAILS_ENV=production rails assets:precompile` to reproduce and trial and error fix.