### PR TITLE
Fix marker creation

### DIFF
--- a/app/controllers/api/v1/connect/markers_controller.rb
+++ b/app/controllers/api/v1/connect/markers_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         def create
-          @marker = ::Connect::Marker.new(marker_params)
+          @marker = ::Connect::Marker.new(marker_params.merge(device_uuid: device_uuid))
           if @marker.save
             render :show, status: :created, location: @marker
           else

--- a/app/controllers/api/v1/connect/markers_controller.rb
+++ b/app/controllers/api/v1/connect/markers_controller.rb
@@ -95,7 +95,6 @@ module Api
                         :phone,
                         :resolved)
                 .tap do |marker|
-                  marker[:device_uuid] = params.dig(:marker, :device_uuid) if action_name == 'create'
                   marker[:categories] = params.dig(:marker, :categories).permit! if params.dig(:marker, :categories)
                   marker[:data] = params.dig(:marker, :data).permit! if params.dig(:marker, :data)
                 end

--- a/test/controllers/api/v1/connect/markers_controller_test.rb
+++ b/test/controllers/api/v1/connect/markers_controller_test.rb
@@ -50,7 +50,7 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create marker" do
-    keys = %w(marker_type name description categories phone latitude longitude data device_uuid)
+    keys = %w(marker_type name description categories phone latitude longitude data)
     attribs = connect_markers(:have).attributes.slice(*keys)
     assert_difference('Connect::Marker.count') do
       post api_v1_connect_markers_path, params: { marker: attribs }, headers: default_headers
@@ -61,7 +61,7 @@ class Api::V1::Connect::MarkersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should not create a marker without a device uuid" do
-    keys = %w(marker_type name description categories phone latitude longitude data device_uuid)
+    keys = %w(marker_type name description categories phone latitude longitude data)
     attribs = connect_markers(:have).attributes.slice(*keys)
     post api_v1_connect_markers_path, params: { marker: attribs }, headers: default_headers({})
     assert_response 403


### PR DESCRIPTION
I screwed up when I converted everything to use the `DisasterConnect-Device-UUID` header.
I left `:device_uuid` in the whitelisted parameters, but neglected to merge the header value into the `create` method. So tests were all green, yet clients were unable to create markers.

This rectifies that screw up.