### PR TITLE
Make icons an object

### DIFF
--- a/config/connect_categories.yml
+++ b/config/connect_categories.yml
@@ -50,12 +50,12 @@ default: &default
   icons:
     # Category keys that need icons will have their
     # corresponding icon key listed here
-    - labor: user-md
-    - equipment: wrench
-    - supplies: shopping-basket
-    - transportation: car
-    - housing: bed
-    - food: cutlery
+    labor: user-md
+    equipment: wrench
+    supplies: shopping-basket
+    transportation: car
+    housing: bed
+    food: cutlery
   en:
     categories: Categories
     labor: Labor

--- a/public/api-docs/swagger-v1.json
+++ b/public/api-docs/swagger-v1.json
@@ -1017,26 +1017,14 @@
             ]
           }
         ],
-        "icons": [
-          {
-            "labor": "user-md"
-          },
-          {
-            "equipment": "wrench"
-          },
-          {
-            "supplies": "shopping-basket"
-          },
-          {
-            "transportation": "car"
-          },
-          {
-            "housing": "bed"
-          },
-          {
-            "food": "cutlery"
-          }
-        ],
+        "icons": {
+          "labor": "user-md",
+          "equipment": "wrench",
+          "supplies": "shopping-basket",
+          "transportation": "car",
+          "housing": "bed",
+          "food": "cutlery"
+        },
         "en": {
           "categories": "Categories",
           "labor": "Labor",


### PR DESCRIPTION
Since the top level categories will be the only categories with
icons, rendering the icons as an array of objects is a bit awkward.
This will make `icons` an object instead of an array of objects.
Each property maps to a top-level category and its associated icon.