### PR TITLE
Flagged content

### DIFF
--- a/app/controllers/api/v1/connect/flags_controller.rb
+++ b/app/controllers/api/v1/connect/flags_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Connect
+      class FlagsController < ApplicationController
+        include DeviceIdentifiable
+
+        def create
+          @marker = ::Connect::Marker.find(params[:marker_id])
+          @marker.flag_as_inappropriate!(device_uuid: device_uuid, reason: params[:reason])
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/connect/markers_controller.rb
+++ b/app/controllers/api/v1/connect/markers_controller.rb
@@ -4,11 +4,11 @@ module Api
   module V1
     module Connect
       class MarkersController < ApplicationController
-        before_action :check_device_uuid, only: [:create, :update]
+        include DeviceIdentifiable
 
         def index
           @filters = {}
-          @markers = ::Connect::Marker.unresolved.all
+          @markers = ::Connect::Marker.unresolved.not_flagged.all
           apply_filters
         end
 
@@ -31,18 +31,6 @@ module Api
         end
 
         private
-
-        def device_uuid
-          request.headers['HTTP_DISASTERCONNECT_DEVICE_UUID']
-        end
-
-        def missing_device_uuid
-          render(json: { device_uuid: ['Must be set with DisasterConnect-Device-UUID header'] }, status: :forbidden)
-        end
-
-        def check_device_uuid
-          missing_device_uuid if device_uuid.blank?
-        end
 
         def apply_filters
           category_filter

--- a/app/controllers/concerns/device_identifiable.rb
+++ b/app/controllers/concerns/device_identifiable.rb
@@ -1,0 +1,21 @@
+module DeviceIdentifiable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :check_device_uuid, only: [:create, :update]
+  end
+
+  private
+
+  def device_uuid
+    request.headers['HTTP_DISASTERCONNECT_DEVICE_UUID']
+  end
+
+  def missing_device_uuid
+    render(json: { device_uuid: ['Must be set with DisasterConnect-Device-UUID header'] }, status: :forbidden)
+  end
+
+  def check_device_uuid
+    missing_device_uuid if device_uuid.blank?
+  end
+end

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -15,12 +15,33 @@ module Connect
     scope :by_category, ->(category) { where('categories ? :category', category: category) }
     scope :by_device_uuid, ->(device_uuid) { where(device_uuid: device_uuid) }
     scope :by_type, ->(type) { where(marker_type: type) }
+    scope :flagged, ->() { where("data ? 'inappropriate_flag'") }
+    scope :not_flagged, ->() { where.not("data ? 'inappropriate_flag'") }
     scope :resolved, -> { where(resolved: true) }
     scope :unresolved, -> { where(resolved: false) }
 
     def coordinates_changed?
       return false if latitude.zero? || longitude.zero?
       latitude_changed? || longitude_changed?
+    end
+
+    def flagged_inappropriate?
+      data.key? 'inappropriate_flag'
+    end
+
+    def flag_as_inappropriate!(device_uuid:, reason:)
+      return if flagged_inappropriate?
+      data['inappropriate_flag'] = {
+        flagged_by: device_uuid,
+        flagged_for: reason,
+        flagged_at: Time.zone.now
+      }
+      save
+    end
+
+    def clear_inappropriate_flag!
+      data.delete('inappropriate_flag')
+      save
     end
   end
 end

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -7,7 +7,7 @@ module Connect
     validates :categories, :device_uuid, :name, :phone, presence: true
     validates :marker_type, inclusion: { in: MARKER_TYPES, allow_blank: false }
     validates :latitude, :longitude, numericality: { other_than: 0 }
-    validates :email, format: { with: /@/, allow_nil: true }
+    validates :email, format: { with: /\A.+@.+\z/, allow_nil: true }
 
     reverse_geocoded_by :latitude, :longitude
     after_validation :reverse_geocode, if: :coordinates_changed?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
       get "/charitable_organizations" => 'charitable_organizations#index'
 
       namespace :connect do
-        resources :markers, only: [:create, :index, :update]
+        resources :markers, only: [:create, :index, :update] do
+          resource :flag, only: :create
+        end
         resources :categories, only: [:index]
       end
     end

--- a/db/migrate/20170920210424_add_index_to_data_on_connect_markers.rb
+++ b/db/migrate/20170920210424_add_index_to_data_on_connect_markers.rb
@@ -1,0 +1,5 @@
+class AddIndexToDataOnConnectMarkers < ActiveRecord::Migration[5.1]
+  def change
+    add_index  :connect_markers, :data, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170911210028) do
+ActiveRecord::Schema.define(version: 20170920210424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20170911210028) do
     t.string "device_uuid", default: "", null: false
     t.jsonb "categories", default: {}, null: false
     t.index ["categories"], name: "index_connect_markers_on_categories", using: :gin
+    t.index ["data"], name: "index_connect_markers_on_data", using: :gin
     t.index ["device_uuid"], name: "index_connect_markers_on_device_uuid"
     t.index ["latitude", "longitude"], name: "index_connect_markers_on_latitude_and_longitude"
     t.index ["resolved"], name: "index_connect_markers_on_unresolved", where: "(resolved IS FALSE)"

--- a/public/api-docs/swagger-v1.json
+++ b/public/api-docs/swagger-v1.json
@@ -37,9 +37,7 @@
       "get": {
         "security": [
           {
-            "device_uuid": [
-
-            ]
+            "device_uuid": []
           }
         ],
         "tags": [
@@ -65,9 +63,7 @@
       "post": {
         "security": [
           {
-            "device_uuid": [
-
-            ]
+            "device_uuid": []
           }
         ],
         "tags": [
@@ -106,6 +102,16 @@
               "$ref": "#/definitions/Marker"
             }
           },
+          "403": {
+            "description": "DisasterConnect-Device-UUID header is missing",
+            "examples": {
+              "json": {
+                "device_uuid": [
+                  "Must be set with DisasterConnect-Device-UUID header"
+                ]
+              }
+            }
+          },
           "422": {
             "description": "invalid input, object invalid",
             "examples": {
@@ -118,25 +124,13 @@
                 ]
               }
             }
-          },
-          "403": {
-            "description": "DisasterConnect-Device-UUID header is missing",
-            "examples": {
-              "json": {
-                "device_uuid": [
-                  "Must be set with DisasterConnect-Device-UUID header"
-                ]
-              }
-            }
           }
         }
       },
       "get": {
         "security": [
           {
-            "device_uuid": [
-
-            ]
+            "device_uuid": []
           }
         ],
         "tags": [
@@ -214,14 +208,12 @@
                     "name": "ChaiOne",
                     "description": "testing needs",
                     "phone": "7138675309",
-                    "categories": {
-                    },
+                    "categories": {},
                     "latitude": 29.7488442,
                     "longitude": -95.4593123,
                     "address": "4800 Hallmark Dr, Houston, TX 77056, USA",
                     "email": null,
-                    "data": {
-                    },
+                    "data": {},
                     "updated_at": "2017-09-04T12:28:58-05:00"
                   },
                   {
@@ -230,14 +222,12 @@
                     "name": "ChaiOne",
                     "description": "testing haves",
                     "phone": "7138675307",
-                    "categories": {
-                    },
+                    "categories": {},
                     "latitude": 29.8488442,
                     "longitude": -95.5593123,
                     "address": "5623 Crawford Rd, Houston, TX 77041, USA",
                     "email": null,
-                    "data": {
-                    },
+                    "data": {},
                     "updated_at": "2017-09-04T14:24:43-05:00"
                   }
                 ],
@@ -267,9 +257,7 @@
       "patch": {
         "security": [
           {
-            "device_uuid": [
-
-            ]
+            "device_uuid": []
           }
         ],
         "tags": [
@@ -315,6 +303,16 @@
               "$ref": "#/definitions/Marker"
             }
           },
+          "403": {
+            "description": "DisasterConnect-Device-UUID header is missing",
+            "examples": {
+              "json": {
+                "device_uuid": [
+                  "Must be set with DisasterConnect-Device-UUID header"
+                ]
+              }
+            }
+          },
           "422": {
             "description": "invalid input, object invalid",
             "examples": {
@@ -327,6 +325,54 @@
                 ]
               }
             }
+          }
+        }
+      }
+    },
+    "/connect/markers/{marker_id}/flag": {
+      "post": {
+        "security": [
+          {
+            "device_uuid": []
+          }
+        ],
+        "tags": [
+          "DisasterConnect"
+        ],
+        "summary": "flag a marker for inappropriate content",
+        "operationId": "flagMarker",
+        "description": "flags a marker that contains inappropriate or objectionable material. Flagged markers will be hidden until reviewed by an admin.\n",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "DisasterConnect-Device-UUID",
+            "type": "string",
+            "required": true,
+            "description": "The device uuid *must* be sent with this request"
+          },
+          {
+            "in": "path",
+            "name": "marker_id",
+            "type": "integer",
+            "required": true,
+            "description": "The marker ID."
+          },
+          {
+            "in": "body",
+            "name": "reason",
+            "description": "The reason why this marker should be removed",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The marker has been flagged. The response will be empty."
           },
           "403": {
             "description": "DisasterConnect-Device-UUID header is missing",
@@ -386,9 +432,6 @@
           }
         ],
         "responses": {
-          "304": {
-            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
-          },
           "200": {
             "description": "OK",
             "examples": {
@@ -441,9 +484,7 @@
                     "are_supplies_needed": true,
                     "tell_us_about_the_supply_needs": null,
                     "anything_else_you_would_like_to_tell_us": "St. Laurence is not needed as a shelter, so we are serving as a collection and distribution site for donations.",
-                    "needs": [
-
-                    ],
+                    "needs": [],
                     "updated_at": "2017-09-05T16:53:11-05:00",
                     "updatedAt": "2017-09-05T16:53:11-05:00",
                     "timestamp": "2017-09-05T16:53:11-05:00",
@@ -452,11 +493,13 @@
                 ],
                 "meta": {
                   "result_count": 2,
-                  "filters": {
-                  }
+                  "filters": {}
                 }
               }
             }
+          },
+          "304": {
+            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
           }
         }
       }
@@ -506,9 +549,6 @@
           }
         ],
         "responses": {
-          "304": {
-            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
-          },
           "200": {
             "description": "OK",
             "examples": {
@@ -626,11 +666,13 @@
                 ],
                 "meta": {
                   "result_count": 2,
-                  "filters": {
-                  }
+                  "filters": {}
                 }
               }
             }
+          },
+          "304": {
+            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
           }
         }
       }
@@ -668,9 +710,6 @@
           }
         ],
         "responses": {
-          "304": {
-            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
-          },
           "200": {
             "description": "OK",
             "examples": {
@@ -709,6 +748,9 @@
                 }
               }
             }
+          },
+          "304": {
+            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
           }
         }
       }
@@ -752,23 +794,20 @@
           }
         ],
         "responses": {
-          "304": {
-            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
-          },
           "200": {
             "description": "OK",
             "examples": {
               "json": {
-                "charitable_organizations": [
-
-                ],
+                "charitable_organizations": [],
                 "meta": {
                   "result_count": 0,
-                  "filters": {
-                  }
+                  "filters": {}
                 }
               }
             }
+          },
+          "304": {
+            "description": "NOT MODIFIED\nThe content has not changed since the last time the end point was called. No data is returned and the client can rerender the previously cached content. The client must send a `If-Modified-Since` or `If-None-Match` header in for the server to respond with a 304."
           }
         }
       }
@@ -809,8 +848,7 @@
         },
         "data": {
           "type": "object",
-          "example": {
-          },
+          "example": {},
           "description": "Any arbitrary JSON data that needs to be included \nwith the marker.\n"
         },
         "description": {

--- a/test/controllers/api/v1/connect/flags_controller_test.rb
+++ b/test/controllers/api/v1/connect/flags_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class Api::V1::Connect::FlagsControllerTest < ActionDispatch::IntegrationTest
+
+  def default_headers(headers = nil)
+    headers || { "DisasterConnect-Device-UUID": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
+  end
+
+  test "can flag a marker for inapproiate content" do
+    marker = connect_markers(:offensive)
+    assert_difference('Connect::Marker.flagged.count', 1) do
+      post api_v1_connect_marker_flag_path(marker),
+        params: { marker_id: marker.id, reason: 'This guy is being a jerk.' },
+        headers: default_headers
+    end
+    assert_response 204
+    marker.reload
+    assert_equal marker.data.dig('inappropriate_flag', 'flagged_for'), 'This guy is being a jerk.'
+    assert_equal marker.data.dig('inappropriate_flag', 'flagged_by'), "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  end
+
+  test "can not flag a marker without a device uuid" do
+    marker = connect_markers(:offensive)
+    post api_v1_connect_marker_flag_path(marker),
+      params: { marker_id: marker.id, reason: 'This guy is being a jerk.' },
+      headers: default_headers({})
+    assert_response 403
+  end
+end

--- a/test/fixtures/connect/markers.yml
+++ b/test/fixtures/connect/markers.yml
@@ -59,3 +59,32 @@ resolved:
   resolved: true
   latitude: 29.776
   longitude: -95.3587
+
+flagged:
+  device_uuid: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  marker_type: need
+  name: Dirty Birdy
+  description: Some really offensive content
+  phone: 713-867-5309
+  categories:
+    foo: bar
+  resolved: false
+  latitude: 29.773700
+  longitude: -95.358611
+  data:
+    inappropriate_flag:
+      flagged_by: yyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+      flagged_for: Frankly I find the idea of a bug that thinks offensive
+      flagged_at: <%= Time.zone.now %>
+
+offensive:
+  device_uuid: zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
+  marker_type: need
+  name: Dirty Birdy
+  description: I need to be a jerk
+  phone: 713-867-5309
+  categories:
+    foo: bar
+  resolved: false
+  latitude: 29.773700
+  longitude: -95.358611

--- a/test/models/connect/marker_test.rb
+++ b/test/models/connect/marker_test.rb
@@ -85,6 +85,14 @@ class Connect::MarkerTest < ActiveSupport::TestCase
     assert Connect::Marker.by_device_uuid(@marker.device_uuid).all? { |m| m.device_uuid == @marker.device_uuid }
   end
 
+  test 'scope flagged' do
+    assert Connect::Marker.flagged.all? { |m| m.data.key?('inappropriate_flag') }
+  end
+
+  test 'scope not_flagged' do
+    assert Connect::Marker.not_flagged.none? { |m| m.data.key?('inappropriate_flag') }
+  end
+
   test 'scope by type' do
     assert Connect::Marker.by_type(@marker.marker_type).all? { |m| m.marker_type == @marker.marker_type }
   end
@@ -95,5 +103,18 @@ class Connect::MarkerTest < ActiveSupport::TestCase
 
   test 'scope unresolved' do
     assert Connect::Marker.unresolved.none? { |m| m.resolved }
+  end
+
+  test 'can flag a marker as inappropriate' do
+    refute @marker.flagged_inappropriate?
+    @marker.flag_as_inappropriate! device_uuid: 'xyz', reason: 'dirty birdy'
+    assert @marker.flagged_inappropriate?
+  end
+
+  test 'can clear an inappropriate flag' do
+    @marker.flag_as_inappropriate! device_uuid: 'xyz', reason: 'dirty birdy'
+    assert @marker.flagged_inappropriate?
+    @marker.clear_inappropriate_flag!
+    refute @marker.flagged_inappropriate?
   end
 end


### PR DESCRIPTION
The app store requires a way flag any user generated content as
inappropriate. Clients can now flag markers as inappropriate.
Flagged markers will remain hidden from public view until reviewed
by an admin. An admin will be able to undo the flag if the content
is deemed appropriate.

The admin portion will follow in a separate pull request.
