### PR TITLE
Flagged content admin

### DIFF
--- a/app/controllers/api/v1/connect/markers_controller.rb
+++ b/app/controllers/api/v1/connect/markers_controller.rb
@@ -15,7 +15,7 @@ module Api
         def create
           @marker = ::Connect::Marker.new(marker_params.merge(device_uuid: device_uuid))
           if @marker.save
-            render :show, status: :created, location: @marker
+            render :show, status: :created, location: api_v1_connect_marker_url(@marker)
           else
             render json: @marker.errors, status: :unprocessable_entity
           end
@@ -24,7 +24,7 @@ module Api
         def update
           @marker = ::Connect::Marker.find_by!(id: params[:id], device_uuid: device_uuid)
           if @marker.update(marker_params)
-            render :show, status: :ok, location: @marker
+            render :show, status: :ok, location: api_v1_connect_marker_url(@marker)
           else
             render json: @marker.errors, status: :unprocessable_entity
           end

--- a/app/controllers/connect/flagged_markers_controller.rb
+++ b/app/controllers/connect/flagged_markers_controller.rb
@@ -1,0 +1,31 @@
+class Connect::FlaggedMarkersController < ApplicationController
+  before_action :authenticate_admin!
+  helper_method :fields
+
+  def index
+    logger.info current_user
+    @flagged_markers = ::Connect::Marker.unresolved.flagged
+  end
+
+  def show
+    @flagged_marker = ::Connect::Marker.find(params[:id])
+  end
+
+  def update
+    ::Connect::Marker.find(params[:id]).update!(resolved: true)
+    logger.info "#{current_user.email} confirmed marker[#{params[:id]}] as inappropriate."
+    redirect_to connect_flagged_markers_url, notice: 'Marker confirmed.'
+  end
+
+  def destroy
+    ::Connect::Marker.find(params[:id]).clear_inappropriate_flag!
+    logger.info "#{current_user.email} cleared marker[#{params[:id]}]."
+    redirect_to connect_flagged_markers_url, notice: 'Marker cleared.'
+  end
+
+  private
+
+  def fields
+    %w(flagged_at flagged_for marker_type name address)
+  end
+end

--- a/app/controllers/connect/markers_controller.rb
+++ b/app/controllers/connect/markers_controller.rb
@@ -1,3 +1,0 @@
-class Connect::MarkersController < ApplicationController
-  before_action :authenticate_admin!
-end

--- a/app/models/connect/marker.rb
+++ b/app/models/connect/marker.rb
@@ -41,7 +41,19 @@ module Connect
 
     def clear_inappropriate_flag!
       data.delete('inappropriate_flag')
-      save
+      save!
+    end
+
+    def flagged_by
+      data.dig 'inappropriate_flag', 'flagged_by'
+    end
+
+    def flagged_for
+      data.dig 'inappropriate_flag', 'flagged_for'
+    end
+
+    def flagged_at
+      data.dig 'inappropriate_flag', 'flagged_at'
     end
   end
 end

--- a/app/views/connect/flagged_markers/index.html.erb
+++ b/app/views/connect/flagged_markers/index.html.erb
@@ -1,0 +1,42 @@
+<h1>Flagged Markers</h1>
+
+<p>
+  These are map markers from the <a href="http://disasterconnect.io/">Disaster Connect app</a>
+  that users have flagged as inappropriate. Markers that have been flagged will be hidden from
+  public view in the apps.
+</p>
+<p>
+  As an admin, you have the ability to clear the flag, which will enable the public to view the
+  marker again. Or, you can confirm that the marker is inappropriate and it will remain hidden
+  from public view and this screen as well.
+</p>
+
+<table id="data-table" class="shared-table">
+  <thead>
+    <tr>
+      <th></th>
+      <% fields.map(&:titleize).each do |header| %>
+        <th><%= header %></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @flagged_markers.each do |row| %>
+      <tr>
+        <td><%= link_to 'Show', connect_flagged_marker_path(row) %></td>
+        <% fields.each do |field| %>
+          <td><%= truncate(row.public_send(field).to_s) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<script>
+window.onload = function() {
+  $('#data-table').DataTable({
+    "order": [[ 1, "desc" ]]
+  });
+};
+</script>

--- a/app/views/connect/flagged_markers/show.html.erb
+++ b/app/views/connect/flagged_markers/show.html.erb
@@ -1,0 +1,35 @@
+<h1>Marker <%= @flagged_marker.id %></h1>
+
+<%= link_to 'Confirm', connect_flagged_marker_path(@flagged_marker),
+            method: :patch,
+            title: "Confirm that this marker is inappropriate",
+            class: "button button-outline" %> |
+<%= link_to 'Clear', connect_flagged_marker_path(@flagged_marker),
+              method: :delete,
+              title: "This marker is fine and should not have been flagged",
+              class: "button button-outline" %> |
+<%= link_to 'Back', connect_flagged_markers_path, class: "button button-outline" %>
+
+<div class="row">
+  <div class="column">
+    <p><strong>Flagged At:</strong> <%= @flagged_marker.flagged_at %></p>
+    <p><strong>Flagged For:</strong> <%= @flagged_marker.flagged_for %></p>
+    <p><strong>Flagged By:</strong> <%= @flagged_marker.flagged_by %></p>
+
+    <h4>Marker Details</h4>
+    <pre><code><%= JSON.pretty_generate @flagged_marker.as_json %></code></pre>
+  </div>
+  <div class="column">
+    <div id="map" style="height: 300px; width: 100%"></div>
+    <script>
+      $(window).ready(function(){
+        simpleMap({
+          selector: "#map",
+          name: "<%= j @flagged_marker.name %>",
+          lat: <%= @flagged_marker.latitude || 0%>,
+          lng: <%= @flagged_marker.longitude || 0%>
+        })
+      })
+    </script>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,7 @@
         <li><%= link_to "AmazonProducts", amazon_products_path %></li>
         <li><%= link_to "Charitable Organizations", charitable_organizations_path %></li>
         <li><%= link_to "Pages", pages_path %></li>
+        <li><%= link_to "Flagged Markers", connect_flagged_markers_path %></li>
       <% end %>
       <div class="right">
         <li class="welcome-span"><span>Welcome <%= user_signed_in? ? current_user.email : "guest" %>!</span></li>

--- a/app/views/shared/_show.html.erb
+++ b/app/views/shared/_show.html.erb
@@ -1,6 +1,6 @@
 <% columns.each_with_index do |column, index| %>
   <p>
     <strong><%= headers[index] %>:</strong>
-    <%= record.send(column) %>
+    <%= record.public_send(column) %>
   </p>
 <% end %>

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -13,7 +13,7 @@
       <tr>
         <td><%= link_to 'Show', row %> / <%= link_to 'Update', [:edit, row] %></td>
         <% columns.each do |column| %>
-          <td><%= truncate(row.send(column).to_s) %></td>
+          <td><%= truncate(row.public_send(column).to_s) %></td>
         <% end %>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   end
   resources :amazon_products, except: [:new, :create, :destroy]
   namespace :connect do
-    resources :markers
+    resources :flagged_markers, only: [:index, :show, :update, :destroy]
   end
 
   root to: "splash#index"

--- a/public/api-docs/swagger-v1.json
+++ b/public/api-docs/swagger-v1.json
@@ -367,7 +367,9 @@
             "in": "body",
             "name": "reason",
             "description": "The reason why this marker should be removed",
-            "type": "string"
+            "schema": {
+              "$ref": "#/definitions/Flag"
+            }
           }
         ],
         "responses": {
@@ -814,6 +816,19 @@
     }
   },
   "definitions": {
+    "Flag": {
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "example": "I find this content highly offensive",
+          "description": "The reason why this marker is being flagged.\n"
+        }
+      }
+    },
     "Marker": {
       "type": "object",
       "required": [

--- a/test/controllers/connect/flagged_markers_controller_test.rb
+++ b/test/controllers/connect/flagged_markers_controller_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class FlaggedMarkersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  fixtures :all
+
+  test "only admins can access index" do
+    get connect_flagged_markers_path
+    assert_redirected_to root_path
+    sign_in users(:admin)
+    get connect_flagged_markers_path
+    assert_response :success
+  end
+
+  test "only admins can access show" do
+    get connect_flagged_marker_path(connect_markers(:flagged))
+    assert_redirected_to root_path
+    sign_in users(:admin)
+    get connect_flagged_marker_path(connect_markers(:flagged))
+    assert_response :success
+  end
+
+  test "Can clear a marker" do
+    sign_in users(:admin)
+    marker = connect_markers(:flagged)
+    assert(marker.flagged_inappropriate?)
+    delete connect_flagged_marker_path(marker)
+    assert_redirected_to connect_flagged_markers_path
+    marker.reload
+    refute(marker.flagged_inappropriate?)
+  end
+
+  test "Can confirm a marker" do
+    sign_in users(:admin)
+    marker = connect_markers(:flagged)
+    assert(marker.flagged_inappropriate?)
+    refute(marker.resolved?)
+    patch connect_flagged_marker_path(marker)
+    assert_redirected_to connect_flagged_markers_path
+    marker.reload
+    assert(marker.flagged_inappropriate?)
+    assert(marker.resolved?)
+  end
+end

--- a/test/controllers/connect/markers_controller_test.rb
+++ b/test/controllers/connect/markers_controller_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class Connect::HavesControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
# Screens to allow admins to manage flagged markers.

The app store requires a way to flag any user generated content as inappropriate.
Users can flag any markers on their device as inappropriate. Flagged markers
receive a `inappropriate_flag` key and are hidden from public view. Under the
`inappropriate_flag` key we also capture when it was flagged, the device that
flagged it, and the reason for doing so.

These records will show up on the "Flagged Markers" page where an admin can
either "confirm" or "clear" the marker. An admin will "confirm" the marker if
they feel the content is inappropriate. This sets the `resolved` flag to true
which keeps the marker out of the public view and removes it from the admin
screens.

If an admin finds nothing wrong with the marker, they can "clear" the marker.
This removes the `inappropriate_flag` key and allows the marker to be viewed by
the public once again. Cleared markers are also removed from the admin screen.

#### Screenshots
![screen shot 2017-09-21 at 4 31 16 am](https://user-images.githubusercontent.com/47318/30692553-9edffaae-9e91-11e7-99e4-5a8738316dd2.png)

![screen shot 2017-09-21 at 6 01 55 am](https://user-images.githubusercontent.com/47318/30692775-9f3933fc-9e92-11e7-8876-427318aaefba.png)
