### PR TITLE
Fix bug in whitelist

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -5,6 +5,8 @@ class OrganizationsController < ApplicationController
   def show
     @organization = params[:organization]
     @organization_tables = Location::Whitelist.organization_tables(@organization)
-    redirect_to root_path if !@organization_tables.present?
+    if !@organization_tables.present?
+      redirect_to root_path, notice: "Unable to find organization."
+    end
   end
 end

--- a/app/models/location/whitelist.rb
+++ b/app/models/location/whitelist.rb
@@ -14,6 +14,8 @@ class Location
     end
 
     def self.organization_tables(organization)
+      return nil if LocationsMap[organization].nil?
+
       keys = LocationsMap[organization].keys.sort
       keys.map { |key| LocationsMap[organization][key] }
     end


### PR DESCRIPTION
If you entered an invalid slug, the app would error instead of redirecting you to the home page.

![unable-to-find-organization](https://user-images.githubusercontent.com/3675297/31304543-dd352640-aae8-11e7-810e-39cc60470478.png)
